### PR TITLE
build: include stdbool.h in c build

### DIFF
--- a/src/panTompkins.h
+++ b/src/panTompkins.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Otherwise:

```
error: unknown type name 'bool' [Semantic Issue]
```